### PR TITLE
Dropping ESLint in favor of Standard.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "env": {
-    "node": true
-  },
-  "rules": {
-    "quotes": [2, "single"]
-  }
-}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Showtimes · a movie showtimes API
 [![NPM](http://img.shields.io/npm/v/showtimes.svg?style=flat)](https://www.npmjs.org/package/showtimes)
 [![Travis CI](http://img.shields.io/travis/erunion/showtimes.svg?style=flat)](https://travis-ci.org/erunion/showtimes)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 ## Installation
 ```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tap test/",
-    "lint": "eslint index.js test/**.js"
+    "lint": "standard index.js test/**.js"
   },
   "dependencies": {
     "cheerio": "^0.18.0",
@@ -36,7 +36,6 @@
     "request": "^2.51.0"
   },
   "devDependencies": {
-    "eslint": "^0.13.0",
     "tap": "^0.5.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,91 +1,72 @@
-'use strict';
-
-var showtimes = require('../');
-var test = require('tap').test;
-var s = null;
+var showtimes = require('../')
+var test = require('tap').test
+var s = null
 
 test('no movies available for a date far in the future', function (t) {
   s = showtimes(90504, {
     date: 200
-  });
+  })
 
   s.getTheaters(function (err) {
-    t.type(err, 'string');
-    t.end();
-  });
-});
+    t.type(err, 'string')
+    t.end()
+  })
+})
 
 test('get theaters from zipcode', function (t) {
-  s = showtimes(90504, {
-    //date: 0
-  });
-
+  s = showtimes(90504)
   s.getTheaters(function (err, theaters) {
-    t.equal(err, null);
-    t.ok(theaters.length > 1);
-    t.end();
-  });
-});
+    t.equal(err, null)
+    t.ok(theaters.length > 1)
+    t.end()
+  })
+})
 
 test('get theaters from zipcode and get movie for first movie id', function (t) {
-  s = showtimes(90504, {
-    //date: 0
-  });
-
+  s = showtimes(90504)
   s.getTheaters(function (err, theaters) {
-    t.equal(err, null);
+    t.equal(err, null)
     s.getMovie((theaters[0].movies[0].id), function (err2, movie) {
-      t.equal(err2, null);
-      t.ok(movie.theaters[0].showtimes.length > 0);
-    });
-    t.end();
-  });
-});
+      t.equal(err2, null)
+      t.ok(movie.theaters[0].showtimes.length > 0)
+    })
 
-test('get theaters from lat/long', function (t) {
-  s = showtimes('33.8358,-118.3406', {
-    //date: 0
-  });
-
-  s.getTheaters(function (err, theaters) {
-    t.equal(err, null);
-    t.ok(theaters.length > 1);
-    t.end();
-  });
-});
-
-test('get movies from lat/long', function (t) {
-  s = showtimes('33.8358,-118.3406', {
-    //date: 0
-  });
-
-  s.getMovies(function (err, movies) {
-    t.equal(err, null);
-    t.ok(movies.length > 1);
-    t.end();
-  });
-});
-
-test('get theaters from lat/long', function (t) {
-  s = showtimes('45.531531531531535,-122.61220863200342', {
-    //date: 0
-  });
-
-  s.getTheaters(function (err, theaters) {
-    t.equal(err, null);
-    t.ok(theaters.length > 1);
-    t.end();
-  });
-});
-
-test('get movies from lat/long', function (t) {
-  s = showtimes('45.531531531531535,-122.61220863200342', {
-    //date: 0
-  });
-
-  s.getMovies(function(err, movies) {
-    t.equal(err, null);
-    t.ok(movies.length > 1);
     t.end()
-  });
-});
+  })
+})
+
+test('get theaters from lat/long', function (t) {
+  s = showtimes('33.8358,-118.3406')
+  s.getTheaters(function (err, theaters) {
+    t.equal(err, null)
+    t.ok(theaters.length > 1)
+    t.end()
+  })
+})
+
+test('get movies from lat/long', function (t) {
+  s = showtimes('33.8358,-118.3406')
+  s.getMovies(function (err, movies) {
+    t.equal(err, null)
+    t.ok(movies.length > 1)
+    t.end()
+  })
+})
+
+test('get theaters from lat/long', function (t) {
+  s = showtimes('45.531531531531535,-122.61220863200342')
+  s.getTheaters(function (err, theaters) {
+    t.equal(err, null)
+    t.ok(theaters.length > 1)
+    t.end()
+  })
+})
+
+test('get movies from lat/long', function (t) {
+  s = showtimes('45.531531531531535,-122.61220863200342')
+  s.getMovies(function (err, movies) {
+    t.equal(err, null)
+    t.ok(movies.length > 1)
+    t.end()
+  })
+})


### PR DESCRIPTION
Having to have a `.eslintrc` file in the repository for coding standards is super lame, and I guess semi-colons aren't that big of a deal in JS. Fine, I'll move over.