### PR TITLE
Adjust some scraper logic to missing data is handled properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ api.getTheaters(function (error, theaters) {
 }
 ```
 
+* `id` is represented as `false` if no theater ID could be obtained (usually only happens on some boutique theaters).
 * `phoneNumber` and `movies` are only available on `getTheaters()`.
 * `showtimes` is only available through `getMovies()` or `getMovie()`.
 * `address` and `phoneNumber` are all optional, and not always present for every theater.

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,14 @@ class showtimes {
       cloakedUrl = $('#left_nav .section a').attr('href')
     }
 
-    var theaterId = cloakedUrl ? qs.parse(url.parse(cloakedUrl).query).tid : ''
+    var theaterId = false
+    if (cloakedUrl) {
+      cloakedUrl = qs.parse(url.parse(cloakedUrl))
+      if (typeof cloakedUrl.tid !== 'undefined') {
+        theaterId = cloakedUrl.tid
+      }
+    }
+
     var info = theater.find('.desc .info').text().split(' - ')
 
     if (alternate) {

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ class showtimes {
         if (theaterData.name.length === 0) {
           return true
         }
+
         api.theaters.push(theaterData)
       })
 
@@ -116,9 +117,8 @@ class showtimes {
       $('.movie').each((i, movie) => {
         movie = $(movie)
         movieData = api._parseMovie($, movie, true)
-
-        if (movieData.name.length === 0) {
-          return true
+        if (!movieData) {
+          return
         }
 
         delete movieData.showtimes
@@ -193,7 +193,8 @@ class showtimes {
     } else {
       cloakedUrl = theater.find('.desc h2.name a').attr('href')
     }
-    // Get the Id from left links XD
+
+    // Get the ID from left links
     if (typeof cloakedUrl === 'undefined') {
       cloakedUrl = $('#left_nav .section a').attr('href')
     }
@@ -221,7 +222,10 @@ class showtimes {
 
     var movies = []
     theater.find('.showtimes .movie').each((j, movie) => {
-      movies.push(api._parseMovie($, $(movie)))
+      movie = api._parseMovie($, $(movie))
+      if (movie) {
+        movies.push(movie)
+      }
     })
 
     return {
@@ -245,6 +249,14 @@ class showtimes {
   _parseMovie ($, movie, alternate, movieId) {
     if (typeof alternate === 'undefined') {
       alternate = false
+    }
+
+    var name = alternate ? movie.find('h2[itemprop=name]').text() : movie.find('.name').text()
+
+    // If the movie doesn't have a name, then there's a good chance that the theater attached to this isn't showing
+    // anything, so let's just not set a movie here.
+    if (name === '') {
+      return false
     }
 
     if (typeof movieId === 'undefined') {
@@ -343,7 +355,7 @@ class showtimes {
 
     var movieData = {
       id: movieId,
-      name: alternate ? movie.find('h2[itemprop=name]').text() : movie.find('.name').text(),
+      name: name,
       runtime: runtime,
       rating: rating,
       genre: genre,

--- a/test/theaters.js
+++ b/test/theaters.js
@@ -66,6 +66,7 @@ test('get theaters from lat/long and get filtered movies for first theaters name
   api = new Showtimes('45.531531531531535,-122.61220863200342')
   api.getTheaters(function (err, theaters) {
     assert.equal(err, null)
+
     var query = theaters[0].name
     api.getMovies(query, function (err2, movies) {
       assert.equal(err2, null)


### PR DESCRIPTION
* If we can't determine an ID for a theater, set the ID as `false`. Fixes #7
* If we can't determine a movie name, don't return that movie in an array of movies for a theater.