### PR TITLE
fix tid on _parseTheater

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,7 @@ class showtimes {
 
       theaterId = false
       if (cloakedUrl) {
-        cloakedUrl = qs.parse(url.parse(cloakedUrl))
+        cloakedUrl = qs.parse(url.parse(cloakedUrl).query)
         if (typeof cloakedUrl.tid !== 'undefined') {
           theaterId = cloakedUrl.tid
         }


### PR DESCRIPTION
`qs.parse` on the `_parseTheater` method was passed the `url.parse` object instead of the `query` key of it, leading to an empty object and no `theaterId`