### PR TITLE
gh-43 Specify `query` attribute of object returned from `url.parse`.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,7 @@ class showtimes {
 
       theaterId = false
       if (cloakedUrl) {
-        cloakedUrl = qs.parse(url.parse(cloakedUrl))
+        cloakedUrl = qs.parse(url.parse(cloakedUrl).query)
         if (typeof cloakedUrl.tid !== 'undefined') {
           theaterId = cloakedUrl.tid
         }

--- a/test/theaters.js
+++ b/test/theaters.js
@@ -11,6 +11,18 @@ test('get theaters from zipcode', function (assert) {
   })
 })
 
+test('get theaters attributes', function (assert) {
+  api = new Showtimes(90504)
+  api.getTheaters(function (err, theaters) {
+    assert.equal(err, null)
+    assert.ok(theaters[0].id, 'id attribute parsed from theater')
+    assert.ok(theaters[0].name, 'name attribute parsed from theater')
+    assert.ok(theaters[0].address, 'address attribute parsed from theater')
+    assert.ok(theaters[0].phoneNumber, 'phoneNumber attribute parsed from theater')
+    assert.end()
+  })
+})
+
 test('get theaters from zipcode and get movie for first movie id', function (assert) {
   api = new Showtimes(90504)
   api.getTheaters(function (err, theaters) {


### PR DESCRIPTION
Add test to check for attributes parsed from the theatre markup.

New test with old code fails.
```
➜  showtimes git:(master) ✗ npm test

> showtimes@2.1.0 test /Users/jaisenmathai/showtimes
> tap test

test/movies.js ...................................... 15/15 9s
test/theaters.js .................................... 22/23 7s
  get theaters attributes
  not ok id attribute parsed from theater
    at:
      file: test/theaters.js
      line: 18
      column: 10
    source: |
      assert.ok(theaters[0].id, 'id attribute parsed from theater')
    stack: |
      test/theaters.js:18:10
      src/index.js:74:9
      Request._callback (src/index.js:521:7)
      Request.self.callback (node_modules/request/request.js:199:22)
      Request.<anonymous> (node_modules/request/request.js:1036:10)
      IncomingMessage.<anonymous> (node_modules/request/request.js:963:12)
      endReadableNT (_stream_readable.js:905:12)

total ............................................... 37/38


  37 passing (16s)
  1 failing

npm ERR! Test failed.  See above for more details.
```

New test with new code passes.
```
➜  showtimes git:(master) ✗ vim src/index.js
➜  showtimes git:(master) ✗ npm test

> showtimes@2.1.0 test /Users/jaisenmathai/showtimes
> tap test

test/movies.js ...................................... 15/15 8s
test/theaters.js .................................... 23/23 7s
total ............................................... 38/38

  38 passing (15s)

  ok
```